### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,6 +8,9 @@
 
 name: Java CI with Maven
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/ryo8000/generic-code-for-java/security/code-scanning/1](https://github.com/ryo8000/generic-code-for-java/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root of the workflow file. This block will apply to all jobs in the workflow unless overridden by job-specific permissions. Since the workflow only requires read access to repository contents (e.g., for checking out code), the `contents: read` permission is sufficient. This change ensures that the `GITHUB_TOKEN` is limited to the least privileges necessary for the workflow to function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
